### PR TITLE
Add `kernel.Task.BlockFD[WithDeadline]`.

### DIFF
--- a/nogo.yaml
+++ b/nogo.yaml
@@ -192,6 +192,10 @@ analyzers:
         - "linkname to unknown symbol"
       exclude:
         - ".*/containerd/sys/subprocess_unsafe_linux.go"
+  SA1017: # Channels used with os/signal.Notify should be buffered.
+    internal:
+      exclude:
+        - pkg/sentry/kernel/signal.go # Intentional.
   SA1019: # Use of deprecated identifier.
     # disable for now due to misattribution from golang.org/issue/44195.
     generated:

--- a/pkg/gohacks/gohacks_unsafe.go
+++ b/pkg/gohacks/gohacks_unsafe.go
@@ -85,6 +85,30 @@ func StringFromImmutableBytes(bs []byte) string {
 // Note that go:linkname silently doesn't work if the local name is exported,
 // necessitating an indirection for exported functions.
 
+// EnterSyscall is runtime.entersyscall.
+//
+// WARNING: It is unsafe to call any functions between runtime.entersyscall
+// and runtime.exitsyscall unless they are defined in the runtime package or in
+// assembly, for reasons explained by a comment in syscall.Syscall.
+//
+//go:nosplit
+func EnterSyscall() {
+	entersyscall()
+}
+
+//go:linkname entersyscall runtime.entersyscall
+func entersyscall()
+
+// ExitSyscall is runtime.exitsyscall.
+//
+//go:nosplit
+func ExitSyscall() {
+	exitsyscall()
+}
+
+//go:linkname exitsyscall runtime.exitsyscall
+func exitsyscall()
+
 // Memmove is runtime.memmove, exported for SeqAtomicLoad/SeqAtomicTryLoad<T>.
 //
 //go:nosplit

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -132,6 +132,19 @@ go_template_instance(
 )
 
 go_template_instance(
+    name = "tidset_atomicptrmap",
+    out = "tidset_atomicptrmap_unsafe.go",
+    package = "kernel",
+    prefix = "tidset",
+    template = "//pkg/sync/atomicptrmap:generic_atomicptrmap",
+    types = {
+        "Key": "int32",
+        "Value": "tidsetValue",
+        "Hasher": "tidsetHasher",
+    },
+)
+
+go_template_instance(
     name = "fd_table_refs",
     out = "fd_table_refs.go",
     package = "kernel",
@@ -234,6 +247,7 @@ go_library(
         "signal.go",
         "signal_handlers.go",
         "signal_handlers_mutex.go",
+        "signal_unsafe.go",
         "socket_list.go",
         "syscalls.go",
         "syscalls_state.go",
@@ -241,6 +255,7 @@ go_library(
         "task.go",
         "task_acct.go",
         "task_block.go",
+        "task_block_unsafe.go",
         "task_cgroup.go",
         "task_clone.go",
         "task_context.go",
@@ -266,6 +281,7 @@ go_library(
         "thread_group_timer_mutex.go",
         "threads.go",
         "threads_impl.go",
+        "tidset_atomicptrmap_unsafe.go",
         "timekeeper.go",
         "timekeeper_state.go",
         "tty.go",
@@ -298,12 +314,14 @@ go_library(
         "//pkg/errors/linuxerr",
         "//pkg/eventchannel",
         "//pkg/fspath",
+        "//pkg/gohacks",
         "//pkg/goid",
         "//pkg/hostarch",
         "//pkg/log",
         "//pkg/marshal",
         "//pkg/marshal/primitive",
         "//pkg/metric",
+        "//pkg/procid",
         "//pkg/refs",
         "//pkg/refsvfs2",
         "//pkg/safemem",

--- a/pkg/sentry/kernel/signal.go
+++ b/pkg/sentry/kernel/signal.go
@@ -16,10 +16,14 @@ package kernel
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
 
+	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
+	"gvisor.dev/gvisor/pkg/sync"
 )
 
 // SignalPanic is used to panic the running threads. It is a signal which
@@ -42,6 +46,9 @@ func (k *Kernel) sendExternalSignal(info *linux.SignalInfo, context string) {
 
 	case platform.SignalInterrupt:
 		// Assume that a call to platform.Context.Interrupt() misfired.
+
+	case SignalInterruptSyscall:
+		// Expected.
 
 	case SignalPanic:
 		// SignalPanic is also specially handled in sentry setup to ensure that
@@ -75,4 +82,75 @@ func SignalInfoNoInfo(sig linux.Signal, sender, receiver *Task) *linux.SignalInf
 	info.SetPID(int32(receiver.tg.pidns.IDOfThreadGroup(sender.tg)))
 	info.SetUID(int32(sender.Credentials().RealKUID.In(receiver.UserNamespace()).OrOverflow()))
 	return info
+}
+
+// SignalInterruptSyscall is sent by Task.interrupt() to task goroutine threads
+// in host syscalls that have atomically unmasked SignalInterruptSyscall.
+// Threads whose IDs may be stored in Task.syscallTID have
+// SignalInterruptSyscall masked when not in said syscalls, ensuring that
+// signal delivery does not occur unless it would interrupt a syscall.
+const SignalInterruptSyscall = linux.SIGPWR
+
+var (
+	// interruptSyscallReadyTIDs stores thread IDs for which
+	// interruptibleSyscallSignalMask has already been called. (This is feasible
+	// because the Go runtime never destroys threads, so thread IDs are never
+	// reused.)
+	interruptSyscallReadyTIDs tidsetAtomicPtrMap
+
+	interruptSyscallInitOnce sync.Once
+	interruptSyscallSigmask  linux.SignalSet // SignalInterruptSyscall is unmasked
+)
+
+// interruptibleSyscallSignalMask ensures that SignalInterruptSyscall is
+// masked by the calling thread, then returns a signal mask not containing
+// SignalInterruptSyscall, for use by the interruptible syscall.
+//
+// Preconditions:
+//   - runtime.LockOSThread() is in effect.
+//   - tid is the caller's thread ID.
+func interruptibleSyscallSignalMask(tid int32) linux.SignalSet {
+	if interruptSyscallReadyTIDs.Load(tid) != nil {
+		return interruptSyscallSigmask
+	}
+	interruptSyscallInitOnce.Do(func() {
+		// Get the current signal mask, assuming that it's the correct signal mask
+		// for all threads on which task goroutines can run.
+		var sigmask linux.SignalSet
+		if err := sigprocmask(0, nil, &sigmask); err != nil {
+			panic(fmt.Sprintf("sigprocmask(0, nil, %p) failed: %v", &sigmask, err))
+		}
+		interruptSyscallSigmask = sigmask &^ linux.SignalSetOf(SignalInterruptSyscall)
+		// SignalInterruptSyscall must be handled by a userspace signal handler to
+		// prevent ppoll(2) from being automatically restarted. The easiest way to
+		// ensure this is to require Go to install a signal handler.
+		// signal.Notify() will perform a non-blocking send to whatever channel we
+		// provide, and we don't actually care about being notified about the
+		// signal, so pass it an unbuffered channel that will never have a
+		// receiver.
+		signal.Notify(make(chan os.Signal), unix.Signal(SignalInterruptSyscall))
+	})
+	sigmask := linux.SignalSetOf(SignalInterruptSyscall)
+	if err := sigprocmask(linux.SIG_BLOCK, &sigmask, nil); err != nil {
+		panic(fmt.Sprintf("sigprocmask(SIG_BLOCK, %p, nil) failed: %v", &sigmask, err))
+	}
+	interruptSyscallReadyTIDs.Store(tid, &tidsetValue{})
+	return interruptSyscallSigmask
+}
+
+type tidsetValue struct{}
+
+type tidsetHasher struct{}
+
+// Init implements generic_atomicptrmap.Hasher.Init.
+func (tidsetHasher) Init() {
+}
+
+// Hash implements generic_atomicptrmap.Hasher.Hash.
+func (tidsetHasher) Hash(tid int32) uintptr {
+	// This hash function is the linear congruential generator defined as
+	// nrand48() by POSIX, with the constant addition removed (since, with
+	// overwhelming probability, it doesn't affect the output due to the bit
+	// shift).
+	return uintptr(uint64(tid) * 0x5deece66d >> 16)
 }

--- a/pkg/sentry/kernel/signal_unsafe.go
+++ b/pkg/sentry/kernel/signal_unsafe.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+)
+
+func sigprocmask(how int32, set, oldset *linux.SignalSet) error {
+	_, _, errno := unix.RawSyscall6(unix.SYS_RT_SIGPROCMASK, uintptr(how), uintptr(unsafe.Pointer(set)), uintptr(unsafe.Pointer(oldset)), linux.SignalSetSize, 0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/pkg/sentry/kernel/task.go
+++ b/pkg/sentry/kernel/task.go
@@ -97,6 +97,13 @@ type Task struct {
 	// interruptChan is always notified after restore (see Task.run).
 	interruptChan chan struct{} `state:"nosave"`
 
+	// If syscallTID is non-zero, it is the task goroutine's current thread ID,
+	// and the task goroutine is blocked in ppoll(2) or epoll_pwait(2) with
+	// SignalInterruptSyscall unmasked.
+	//
+	// syscallTID is owned by the task goroutine.
+	syscallTID atomicbitops.Int32
+
 	// gosched contains the current scheduling state of the task goroutine.
 	//
 	// gosched is protected by goschedSeq. gosched is owned by the task

--- a/pkg/sentry/kernel/task_block_unsafe.go
+++ b/pkg/sentry/kernel/task_block_unsafe.go
@@ -1,0 +1,67 @@
+// Copyright 2022 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/gohacks"
+	"gvisor.dev/gvisor/pkg/procid"
+)
+
+//go:norace
+//go:nosplit
+func (t *Task) blockPollUnsafe(pfds []linux.PollFD, timeout *linux.Timespec) (int, error) {
+	for {
+		runtime.LockOSThread()
+		tid := int32(procid.Current())
+		sigmask := interruptibleSyscallSignalMask(tid)
+		t.syscallTID.Store(tid)
+		gohacks.EnterSyscall()
+		var (
+			un    uintptr
+			errno unix.Errno
+		)
+		if len(pfds) == 0 {
+			un, _, errno = unix.RawSyscall6(unix.SYS_PPOLL, 0, 0, uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(&sigmask)), linux.SignalSetSize, 0)
+		} else {
+			un, _, errno = unix.RawSyscall6(unix.SYS_PPOLL, uintptr(unsafe.Pointer(&pfds[0])), uintptr(len(pfds)), uintptr(unsafe.Pointer(timeout)), uintptr(unsafe.Pointer(&sigmask)), linux.SignalSetSize, 0)
+		}
+		// Call UnlockOSThread(), which is safely nosplit and in the runtime
+		// package, so that if we lost our P to sysmon and need to reschedule in
+		// exitsyscall(), the Go runtime doesn't need to wake this thread to resume
+		// our execution (increasing our wakeup latency).
+		runtime.UnlockOSThread()
+		gohacks.ExitSyscall()
+		t.syscallTID.Store(0)
+		if un != 0 {
+			return int(un), nil
+		}
+		if errno == 0 {
+			return 0, linuxerr.ETIMEDOUT
+		}
+		if errno != unix.EINTR {
+			return 0, errno
+		}
+		if t.interrupted() {
+			return 0, linuxerr.ErrInterrupted
+		}
+		// Spurious interrupt; retry.
+	}
+}


### PR DESCRIPTION
Before this CL, using `kernel.Task.Block*` to wait for host FD readiness requires going through fdnotifier, resulting in a significant amount of overhead. As an example, consider a blocking application `recvmsg` on a hostinet socket that blocks:

- The task goroutine invokes `recvmsg` and gets `EAGAIN`.

- The task goroutine heap-allocates a `waiter.Entry` and a channel of `waiter.EventMask`, and invokes `epoll_ctl` to add the socket FD to fdnotifier's epoll FD.

- The task goroutine invokes `recvmsg` and gets `EAGAIN`, again.

- The task goroutine blocks in Go (on the channel select in `kernel.Task.block`). If the thread that was running the task goroutine can find idle goroutines to run, then it does so; otherwise, it invokes `futex(FUTEX_WAIT)` to block in the host.

  Note that the vast majority of the sentry's "work" consists of executing application code, during which the corresponding task goroutines appear to the Go scheduler to be blocked in host syscalls; furthermore, time that *is* spent executing sentry code (in Go) is overhead relative to the application's execution. Consequently, the sentry has relatively little Go code to execute and is generally optimized to have less, making this tradeoff less favorable than in (presumably) more typical Go programs.

- When the socket FD becomes readable, fdnotifier's goroutine returns from `epoll_wait` and wakes the task goroutine, usually invoking `futex(FUTEX_WAKE)` to wake another thread. It then yields control of its thread to other goroutines, improving wakeup-to-execution latency for the task goroutine.

  The `futex(FUTEX_WAKE)` is skipped if any of the following are true:

  - `GOMAXPROCS` threads are already executing goroutines. For reasons described above, we expect this to occur infrequently.

  - At least one already-running thread is in the "spinning" state, because it was itself recently woken but has not yet started executing goroutines.

  - At least one already-running thread is in the "spinning" state, because it recently ran out of goroutines to run and is busy-polling before going to sleep.

  A "spinning" thread stops spinning either because it successfully busy-polls
  for an idle goroutine to run, or it times out while busy-polling in the
  latter case; in the former case the thread usually invokes
  `futex(FUTEX_WAKE)` to wake *another* thread as described above, and in the
  latter case the thread invokes `futex(FUTEX_WAIT)` to go to sleep.

- The task goroutine invokes `recvmsg` and succeeds.

- The task goroutine invokes `epoll_ctl` to remove the socket FD from fdnotifier's epoll FD.

This CL demonstrates how fdnotifier may be replaced by making host syscalls from task goroutine context. After this CL, after per-thread initialization (`sigprocmask`), the same scenario results in:

- The task goroutine invokes `recvmsg` and gets `EAGAIN`.

- The task goroutine invokes `ppoll` on the host FD, which returns when the socket FD becomes available.

  The Go runtime maintains a thread called "sysmon" which runs periodically. When this thread determines that another thread has been blocked in a host syscall for "long enough" (20-40us + slack) and there are idle goroutines to run, it steals that thread's runqueue and invokes `futex(FUTEX_WAKE)` to wake another thread to run the stolen runqueue.

- The task goroutine invokes `recvmsg` and succeeds.

For now, this functionality is only used in hostinet where socket methods are responsible for blocking; applying it more generally (e.g. to `read(2)` from hostinet sockets) requires additional work to move e.g. `read(2)` blocking from `//pkg/sentry/syscalls/linux` into file description implementations.

Some of the overheads before this CL are tractable without removing fdnotifier. The `sleep` package only requires one allocation - of `sleep.Waker` - per registration, and the `syncevent` package requires none. `EventRegister` can return the last known readiness mask to avoid the second `recvmsg`. However, the interactions with the Go runtime - and in particular the many `FUTEX_WAKE`s we incur when waking goroutines due to `ready() -> wakep() -> schedule() -> resetspinning() -> wakep()` - are not. The leading alternative solutions to the same problem are `sleep.Sleeper.AssertAndFetch` and "change the Go runtime". The former is very dubiously safe; it works by transiently lying about `runtime.sched.nmspinning`, a global variable, and not calling `runtime.resetspinning()` when it stops lying, so side effects start at "`runtime.wakep()` is disabled globally rather than only on the caller's thread" and go from there. The latter is dubiously tractable for reasons including the atypicality of the sentry described above, though see https://github.com/golang/go/issues/54622.

PiperOrigin-RevId: 478129654